### PR TITLE
Remove trailing slash from `url` and `enforce_ssl`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,8 +48,8 @@ google_analytics:
 
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed
-url: https://chippydip.github.io/
-enforce_ssl: https://chippydip.github.io/
+url: https://chippydip.github.io
+enforce_ssl: https://chippydip.github.io
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
Jekyll already adds the slash when generating URLs